### PR TITLE
Fix the verbose output

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ From there you can use pip to install it:
 1.0.8
 
 - Corrected project URL in project metadata (thanks Jonathan Moss)
+- Fix verbose output
 
 1.0.7
 

--- a/pactman/verifier/command_line.py
+++ b/pactman/verifier/command_line.py
@@ -70,6 +70,7 @@ parser.add_argument('-q', '--quiet', default=False, action='store_true',
 
 class CaptureResult(Result):
     def __init__(self):
+        log = logging.getLogger('pactman')
         log.handlers = [self]
         log.setLevel(logging.DEBUG)
         self.messages = []


### PR DESCRIPTION
The `-v` verbose message was not displayed when the option was selected. So, I added the relevant logging to fix that