### PR TITLE
Fixed some issues in query and header rule application, and in pact v3 generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,13 @@ From there you can use pip to install it:
 
 ## Release History
 
+2.3.0
+
+- Fix some issues around mocking request queries and the mock's verification of same
+- Fix header regex matching in mock verification
+- Actually use the version passed in to `has_pact_with()`
+- Fix some pact v3 generation issues (thanks pan Jacek)
+
 2.2.0
 
 - Reinstate lost result output.

--- a/pactman/mock/matchers.py
+++ b/pactman/mock/matchers.py
@@ -199,6 +199,8 @@ def from_term(term):
         raise ValueError('Unknown type: %s' % type(term))
 
 
+# For backwards compatiblity with test code that uses pact-python to declare pacts,
+# allow the various classes from that package to also be used to define rules
 try:
     import pact as pact_python
     LIKE_CLASSES = (Like, pact_python.Like)

--- a/pactman/mock/mock_urlopen.py
+++ b/pactman/mock/mock_urlopen.py
@@ -104,7 +104,6 @@ class MockURLOpenHandler(PactRequestHandler):
                 headers['Content-Type'] = 'application/json; charset=utf-8'
         else:
             body = io.BytesIO(b'')
-        print(interaction['response'])
         return HTTPResponse(body=body,
                             status=interaction['response']['status'],
                             preload_content=False,

--- a/pactman/mock/mock_urlopen.py
+++ b/pactman/mock/mock_urlopen.py
@@ -104,7 +104,7 @@ class MockURLOpenHandler(PactRequestHandler):
                 headers['Content-Type'] = 'application/json; charset=utf-8'
         else:
             body = io.BytesIO(b'')
-
+        print(interaction['response'])
         return HTTPResponse(body=body,
                             status=interaction['response']['status'],
                             preload_content=False,

--- a/pactman/mock/pact.py
+++ b/pactman/mock/pact.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import os
 
+import semver
 from pactman.mock.request import Request
 from pactman.mock.response import Response
 from .mock_server import getMockServer
@@ -95,6 +96,7 @@ class Pact(object):
         self.sslcert = sslcert
         self.sslkey = sslkey
         self.version = version
+        self.semver = semver.parse(self.version)
         self.use_mocking_server = use_mocking_server
         self._interactions = []
         self._mock_handler = None

--- a/pactman/mock/pact.py
+++ b/pactman/mock/pact.py
@@ -112,12 +112,37 @@ class Pact(object):
         When the provider verifies this contract, they will use this field to
         setup pre-defined data that will satisfy the response expectations.
 
-        :param provider_state: The short sentence that is unique to describe
-            the provider state for this contract.
+        In pact v2 the provider state is a short sentence that is unique to describe
+        the provider state for this contract. For example:
+
+            "an alligator with the given name Mary exists and the user Fred is logged in"
+
+        In pact v3 the provider state is a list of state specifications with a name and
+        associated params to define specific values for the state. For example:
+
+            [
+                {
+                    "name": "an alligator with the given name exists",
+                    "params": {"name" : "Mary"}
+                }, {
+                    "name": "the user is logged in",
+                    "params" : { "username" : "Fred"}
+                }
+            ]
+
+        :param provider_state: The state as described above.
         :type provider_state: basestring
         :rtype: Pact
         """
-        self._interactions.insert(0, {'provider_state': provider_state})
+        if self.semver["major"] < 3:
+            provider_state_key = 'providerState'
+            if not isinstance(provider_state, str):
+                raise ValueError('pact v2 provider states must be strings')
+        else:
+            provider_state_key = 'providerStates'
+            if not isinstance(provider_state, list):
+                raise ValueError('pact v3+ provider states must be lists of {name: "", params: {}} specs')
+        self._interactions.insert(0, {provider_state_key: provider_state})
         return self
 
     def setup(self):

--- a/pactman/mock/request.py
+++ b/pactman/mock/request.py
@@ -70,7 +70,17 @@ class Request:
         body_rules = get_matching_rules_v3(self.body, '$')
         if body_rules:
             matchingRules['body'] = body_rules
-        query_rules = get_matching_rules_v3(self.query, '$.query')
+        query_rules = get_matching_rules_v3(self.query, 'query')
         if query_rules:
-            matchingRules['query'] = query_rules['$.query']
+            expand_query_rules(query_rules)
+            matchingRules['query'] = query_rules
         return matchingRules
+
+
+def expand_query_rules(rules):
+    # the matchers will be coded to JSON paths, and we need to extract them out to a dictionary
+    # the keys generated will look like 'query.param[*]' and we need to extract "param"
+    for k in list(rules):
+        matchers = rules.pop(k)
+        rule_param = k[6:-3]
+        rules[rule_param] = matchers

--- a/pactman/mock/request.py
+++ b/pactman/mock/request.py
@@ -78,9 +78,12 @@ class Request:
 
 
 def expand_query_rules(rules):
-    # the matchers will be coded to JSON paths, and we need to extract them out to a dictionary
-    # the keys generated will look like 'query.param[*]' and we need to extract "param"
-    for k in list(rules):
-        matchers = rules.pop(k)
-        rule_param = k[6:-3]
+    # Query rules in the pact JSON are declared without the array notation (even though they always
+    # match arrays).
+    # The matchers will be coded to JSON paths by get_matching_rules_v3, and we need to extract
+    # them out to a dictionary where the original rule path will look like 'query.param[*]'
+    # and we need to extract "param".
+    for rule_path in list(rules):
+        matchers = rules.pop(rule_path)
+        rule_param = rule_path[6:-3]
         rules[rule_param] = matchers

--- a/pactman/test/test_matching_rules.py
+++ b/pactman/test/test_matching_rules.py
@@ -16,7 +16,7 @@ from pactman.verifier.matching_rule import (
 def test_stringify():
     r = MatchType('$', {'match': 'type'})
     assert str(r) == "Rule match by {'match': 'type'} at $"
-    assert repr(r) == "<MatchType $ {'match': 'type'}>"
+    assert repr(r) == "<MatchType path='$' rule={'match': 'type'}>"
 
 
 def test_invalid_match_type(monkeypatch):
@@ -25,17 +25,18 @@ def test_invalid_match_type(monkeypatch):
     log.warning.assert_called_once()
 
 
-@pytest.mark.parametrize('path, weight', [
-    ('$.body', 0),
-    ('$.body.item1.level[0].id', 0),
-    ('$.body.item1.level[1].id', 64),
-    ('$.body.item1.level[*].id', 32),
-    ('$.body.*.level[*].id', 16),
+@pytest.mark.parametrize('path, weight, spam_weight', [
+    ('$.body', 4, 4),
+    ('$.body.item1.level[0].id', 0, 0),
+    ('$.body.item1.level[1].id', 64, 0),
+    ('$.body.item1.level[*].id', 32, 0),
+    ('$.body.*.level[*].id', 16, 0),
+    ('$.body.*.*[*].id', 8, 8),
 ])
-def test_weightings(path, weight):
+def test_weightings(path, weight, spam_weight):
     rule = Matcher(path, {'match': 'type'})
     assert rule.weight(['$', 'body', 'item1', 'level', 1, 'id']) == weight
-    assert rule.weight(['$', 'body', 'item2', 'spam', 1, 'id']) == 0
+    assert rule.weight(['$', 'body', 'item2', 'spam', 1, 'id']) == spam_weight
 
 
 @pytest.mark.parametrize('path, result', [
@@ -57,16 +58,16 @@ def test_split_path(path, result):
     assert list(split_path(path)) == result
 
 
-@pytest.mark.parametrize('path, other, result', [
+@pytest.mark.parametrize('spec, test, result', [
     (['a'], ['b'], 0),
     (['*'], ['a'], 1),
     (['a', '*'], ['a', 'b'], 2),
     (['a', 'b'], ['a', 'b'], 4),
     (['a', 'b', 'c'], ['a', 'b'], 0),
-    (['a', 'b'], ['a', 'b', 'c'], 0),
+    (['a', 'b'], ['a', 'b', 'c'], 4),
 ])
-def test_weight_path(path, other, result):
-    assert weight_path(path, other) == result
+def test_weight_path(spec, test, result):
+    assert weight_path(spec, test) == result
 
 
 @pytest.mark.parametrize('data, spec', [

--- a/pactman/test/test_mock_request.py
+++ b/pactman/test/test_mock_request.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from pactman import Term
+from pactman import Term, Like
 from pactman.mock.request import Request
 
 
@@ -44,6 +44,35 @@ class RequestTestCase(TestCase):
             'matchingRules': {
                 '$.path': {
                     'regex': r'\/.+'
+                }
+            }
+        })
+
+    def test_matcher_in_query(self):
+        target = Request('GET', '/test-path', query={'q': [Like('spam')], 'l': [Term(r'\d+', '10')]})
+        result = target.json('3.0.0')
+        self.maxDiff = None
+        self.assertEqual(result, {
+            'method': 'GET',
+            'path': '/test-path',
+            'query': {'q': ['spam'], 'l': ['10']},
+            'matchingRules': {
+                'query': {
+                    'q': {
+                        'matchers': [
+                            {
+                                'match': 'type'
+                            },
+                        ]
+                    },
+                    'l': {
+                        'matchers': [
+                            {
+                                'match': 'regex',
+                                'regex': r'\d+',
+                            }
+                        ]
+                    },
                 }
             }
         })

--- a/pactman/test/test_pact_generation.py
+++ b/pactman/test/test_pact_generation.py
@@ -1,0 +1,91 @@
+import pytest
+import semver
+from unittest.mock import Mock, mock_open, patch
+import os
+from pactman.mock.pact_request_handler import Config, MockPact, PactRequestHandler
+
+
+@pytest.fixture
+def config_patched(monkeypatch):
+    monkeypatch.setattr(Config, "allocate_port", Mock())
+    monkeypatch.setattr(os, "remove", Mock())
+    monkeypatch.setattr(os.path, "exists", Mock())
+    os.path.exists.return_value = True
+    consumer_name = "CONSUMER"
+    provider_name = "PROVIDER"
+    log_dir = "/tmp/a"
+    pact_dir = "/tmp/pact"
+    version = "2.0.0"
+    my_conf = Config(consumer_name, provider_name, log_dir, pact_dir, None, version)
+    return my_conf
+
+
+@pytest.mark.parametrize("file_write_mode", [None, "overwrite"])
+def test_config_init(monkeypatch, file_write_mode):
+    monkeypatch.setattr(Config, "allocate_port", Mock())
+    monkeypatch.setattr(Config, "pact_filename", Mock())
+    file_name = "/tmp/pact/JSON"
+    Config.pact_filename.return_value = file_name
+    monkeypatch.setattr(os, "remove", Mock())
+    monkeypatch.setattr(os.path, "exists", Mock())
+    os.path.exists.return_value = True
+
+    consumer_name = "CONSUMER"
+    provider_name = "PROVIDER"
+    log_dir = "/tmp/a"
+    pact_dir = "/tmp/pact"
+    version = "2.0.0"
+    my_conf = Config(consumer_name, provider_name, log_dir, pact_dir, file_write_mode, version)
+
+    assert(my_conf.consumer_name == consumer_name)
+    assert(my_conf.provider_name == provider_name)
+    assert(my_conf.log_dir == log_dir)
+    assert(my_conf.file_write_mode == file_write_mode)
+    assert(my_conf.version == version)
+    assert(my_conf.semver == semver.parse(version))
+    my_conf.allocate_port.assert_called_once_with()
+    assert(my_conf.PORT_NUMBER == 8150)
+    if file_write_mode == "overwrite":
+        my_conf.pact_filename.assert_called_once_with()
+        os.path.exists.assert_called_once_with(file_name)
+        os.remove.assert_called_once_with(file_name)
+    else:
+        my_conf.pact_filename.assert_not_called()
+
+
+def test_config_pact_filename(config_patched):
+    res = config_patched.pact_filename()
+    assert(res == os.path.join(config_patched.pact_dir, "CONSUMER-PROVIDER-pact.json"))
+
+
+def test_mock_init(config_patched):
+    my_pact = MockPact(config_patched)
+    assert(my_pact.provider == config_patched.provider_name)
+    assert(my_pact.version == config_patched.version)
+    assert(my_pact.semver == config_patched.semver)
+
+
+def test_pact_request_handler_init(config_patched):
+    my_pact = PactRequestHandler(config_patched)
+    assert(my_pact.config == config_patched)
+
+
+@pytest.mark.parametrize("version", ["2.0.0", "3.0.0"])
+@patch("builtins.open", new_callable=mock_open, read_data="data")
+def test_pact_request_handler_write_pact(monkeypatch, config_patched, version):
+    config_patched.version = version
+    config_patched.semver = semver.parse(version)
+    my_pact = PactRequestHandler(config_patched)
+    os.path.exists.side_effect = [True, False]
+    expected_pact = {
+        "consumer": "CONSUMER" if version[0] == "2" else {"name": "CONSUMER"},
+        "provider": "PROVIDER" if version[0] == "2" else {"name": "PROVIDER"},
+        "interactions": [None],
+        "metadata": {
+            'pactSpecification': {'version': version}
+        }
+    }
+    with patch("json.dump", Mock()) as json_mock:
+        my_pact.write_pact(None)
+        open.assert_called_once_with(my_pact.config.pact_filename(), "w")
+        json_mock.assert_called_once_with(expected_pact, open(), indent=2)

--- a/pactman/test/test_verifier.py
+++ b/pactman/test/test_verifier.py
@@ -9,7 +9,6 @@ import semver
 from restnavigator import Navigator
 
 from pactman.verifier.broker_pact import BrokerPact, BrokerPacts, pact_id
-from pactman.verifier.matching_rule import log, rule_matchers_v2, rule_matchers_v3
 from pactman.verifier.result import Result
 from pactman.verifier.verify import Interaction, RequestVerifier, ResponseVerifier
 
@@ -47,7 +46,8 @@ def fake_pact(fake_interaction):
 @pytest.fixture
 def mock_pact():
     def create_mock(version):
-        return Mock(provider='SpamProvider', consumer='SpamConsumer', version=semver.parse(version))
+        return Mock(provider='SpamProvider', consumer='SpamConsumer', version=version,
+                    semver=semver.parse(version))
     return create_mock
 
 
@@ -330,29 +330,6 @@ def test_response_verifier(fake_interaction, mock_pact):
     fake_interaction['response']['headers'] = {'Content-Type': 'json-yeah'}
     r = ResponseVerifier(mock_pact('2.0.0'), fake_interaction['response'], Mock())
     r.verify(Mock(status_code=200, headers={'Content-Type': 'json-yeah'}, json=Mock(return_value=dict(a='b', c='c'))))
-
-
-def test_build_matching_rules_handles_rule_with_unknown_type_v2(monkeypatch, fake_interaction, mock_pact):
-    monkeypatch.setattr(log, 'warning', Mock())
-    rules = rule_matchers_v2({
-        "$.body": {"match": "SPAM"},
-        "$.body[*].*": {"match": "type"}
-    })
-    print(rules)
-    assert 2 == len(rules['body'])
-    log.warning.assert_called_once()
-
-
-def test_build_matching_rules_handles_rule_with_unknown_type_v3(monkeypatch, fake_interaction, mock_pact):
-    monkeypatch.setattr(log, 'warning', Mock())
-    rules = rule_matchers_v3({
-        "body": {
-            "$": {"matchers": [{"match": "SPAM"}]},
-            "$[*].*": {"matchers": [{"match": "type"}]}
-        }
-    })
-    assert 2 == len(rules['body'])
-    log.warning.assert_called_once()
 
 
 class FakeResponse:

--- a/pactman/test/testcases-version-3/request/header fails with regex.json
+++ b/pactman/test/testcases-version-3/request/header fails with regex.json
@@ -1,0 +1,28 @@
+{
+  "match": false,
+  "comment": "Headers match with regex",
+  "expected" : {
+    "headers": {
+      "Accept": "alligators",
+      "Content-Type": "hippos"
+    },
+    "matchingRules": {
+      "header": {
+        "Accept": {
+          "matchers": [
+            {
+              "match": "regex",
+              "regex": "\\d+"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "actual": {
+    "headers": {
+      "Content-Type": "hippos",
+      "Accept": "godzilla"
+    }
+  }
+}

--- a/pactman/test/testcases-version-3/request/query detects mismatch with like.json
+++ b/pactman/test/testcases-version-3/request/query detects mismatch with like.json
@@ -1,0 +1,45 @@
+{
+  "match": false,
+  "comment": "Queries with a single like and and explicit match will fail",
+  "expected" : {
+    "method": "GET",
+    "path": "/path",
+    "query": {
+      "alligator": ["Mary"],
+      "hippo": ["John"]
+    },
+    "headers": {"Accept": "alligators"},
+    "matchingRules": {
+      "query": {
+        "hippo": {
+          "matchers": [
+            {
+              "match": "type"
+            }
+          ]
+        }
+      },
+      "header": {
+        "Accept": {
+          "matchers": [
+            {
+              "match": "regex",
+              "regex": "\\w+"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "actual": {
+    "method": "GET",
+    "path": "/path",
+    "query": {
+      "alligator": ["Alex"],
+      "hippo": ["Fred"]
+    },
+    "headers": {
+      "Accept": "godzilla"
+    }
+  }
+}

--- a/pactman/test/testcases-version-3/request/query matches with like.json
+++ b/pactman/test/testcases-version-3/request/query matches with like.json
@@ -1,0 +1,40 @@
+{
+  "match": true,
+  "comment": "Queries match with like",
+  "expected" : {
+    "method": "GET",
+    "path": "/path",
+    "query": {
+      "alligator": ["Mary"],
+      "hippo": ["John"]
+    },
+    "headers": {},
+    "matchingRules": {
+      "query": {
+        "hippo": {
+          "matchers": [
+            {
+              "match": "type"
+            }
+          ]
+        },
+        "alligator": {
+          "matchers": [
+            {
+              "match": "type"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "actual": {
+    "method": "GET",
+    "path": "/path",
+    "query": {
+      "alligator": ["Alex"],
+      "hippo": ["Fred"]
+    },
+    "headers": {}
+  }
+}

--- a/pactman/verifier/broker_pact.py
+++ b/pactman/verifier/broker_pact.py
@@ -59,9 +59,10 @@ class BrokerPact:
         self.metadata = pact['metadata']
         if 'pactSpecification' in self.metadata:
             # the Ruby implementation generates non-compliant metadata, handle that :-(
-            self.version = semver.parse(self.metadata['pactSpecification']['version'])
+            self.version = self.metadata['pactSpecification']['version']
         else:
-            self.version = semver.parse(self.metadata['pact-specification']['version'])
+            self.version = self.metadata['pact-specification']['version']
+        self.semver = semver.parse(self.version)
         self.interactions = [Interaction(self, interaction, result_factory) for interaction in pact['interactions']]
         self.broker_pact = broker_pact
 

--- a/pactman/verifier/matching_rule.py
+++ b/pactman/verifier/matching_rule.py
@@ -56,7 +56,8 @@ def weight_path(spec_path, element_path):
     In spec version 2 paths should always start with ['$', 'body'] and contain object element names or array indexes.
 
     In spec version 3 the path "context" element (like 'body') is moved outside of the path, and the path contains
-    just the elements inside the path, always starting at the root '$', so the shortest path is now ['$'].
+    just the elements inside the path. For bodies this always starts at the root '$', so the shortest body path is
+    now ['$'].
 
     Weighting is calculated as:
 
@@ -69,7 +70,8 @@ def weight_path(spec_path, element_path):
 
     Return the numeric score.
     """
-    if len(spec_path) != len(element_path):
+    # if the spec path is more specific than the element path it'll never match
+    if len(spec_path) > len(element_path):
         return 0
     score = 1
     for spec, element in zip(spec_path, element_path):
@@ -115,7 +117,7 @@ class Matcher:
         self.rule = rule
 
     def __repr__(self):
-        return f'<{self.__class__.__name__} {self.path} {self.rule}>'
+        return f'<{self.__class__.__name__} path={self.path!r} rule={self.rule}>'
 
     def __str__(self):
         return f'Rule match by {self.rule} at {self.path}'

--- a/pactman/verifier/matching_rule.py
+++ b/pactman/verifier/matching_rule.py
@@ -128,7 +128,8 @@ class Matcher:
 
         Return the weight, or 0 if there is no match.
         """
-        return weight_path(list(split_path(self.path)), ['$'] + element_path)
+        print('weighting', element_path, 'for', self)
+        return weight_path(list(split_path(self.path)), element_path)
 
     def check_min(self, data, path):
         if 'min' not in self.rule:
@@ -350,7 +351,12 @@ def rule_matchers_v3(rules):
         # "path" rules are a bit different - there's no jsonpath as there's only a single value to compare, so we
         # hard-code the path to '$' which always matches when looking for weighted path matches
         matchers['path'] = [MultipleMatchers('$', **rules['path'])]
-    for section in ['query', 'header', 'body']:
+    if 'query' in rules:
+        # "query" rules are a bit different too - matchingRules are a flat single-level dictionary of keys which map to
+        # array elements, so alter the path such that the rule maps to that array
+        matchers['query'] = [Matcher.get_matcher(path + '[*]', rule)
+                             for path, rule in rules['query'].items()]
+    for section in ['header', 'body']:
         if section in rules:
             matchers[section] = [Matcher.get_matcher(path, rule)
                                  for path, rule in rules[section].items()]

--- a/pactman/verifier/matching_rule.py
+++ b/pactman/verifier/matching_rule.py
@@ -128,7 +128,6 @@ class Matcher:
 
         Return the weight, or 0 if there is no match.
         """
-        print('weighting', element_path, 'for', self)
         return weight_path(list(split_path(self.path)), element_path)
 
     def check_min(self, data, path):
@@ -353,7 +352,8 @@ def rule_matchers_v3(rules):
         matchers['path'] = [MultipleMatchers('$', **rules['path'])]
     if 'query' in rules:
         # "query" rules are a bit different too - matchingRules are a flat single-level dictionary of keys which map to
-        # array elements, so alter the path such that the rule maps to that array
+        # array elements, but the data they match is keys mapping to an array, so alter the path such that the rule
+        # maps to that array: "Q1" becomes "Q1[*]"
         matchers['query'] = [Matcher.get_matcher(path + '[*]', rule)
                              for path, rule in rules['query'].items()]
     for section in ['header', 'body']:

--- a/pactman/verifier/verify.py
+++ b/pactman/verifier/verify.py
@@ -164,7 +164,6 @@ class ResponseVerifier:
             log.debug(f'.. response {response.text}')
             return self.result.fail(f'{self.interaction_name} status code {response.status_code} is not '
                                     f'expected {self.status}')
-        print('ASDFASDFASDF', self.headers)
         if self.headers is not MISSING:
             for header in self.headers:
                 expected = self.headers[header]

--- a/pactman/verifier/verify.py
+++ b/pactman/verifier/verify.py
@@ -114,7 +114,10 @@ class Interaction:
                 reason = str(e)
             return self.result.fail(f'Unable to configure provider state {state!r} at {setup_url}: {reason}')
         if r.status_code != 200:
-            log.debug(f'HTTP {r.status_code} from provider state setup URL: {r.text}')
+            text = repr(r.text)
+            if len(text) > 60:
+                text = text[:60] + '...' + text[-1]
+            log.debug(f'HTTP {r.status_code} from provider state setup URL: {text}')
             return self.result.fail(f'Invalid provider state {state!r}')
         log.info(f'Using provider state {state!r}')
         return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [coverage:report]
-omit = pactman/verifier/pytest_plugin.py, pactman/verifier/command_line.py, pactman/test/*
+omit = pactman/verifier/pytest_plugin.py, pactman/verifier/command_line.py, pactman/test/*, pactman/__version__.py
 exclude_lines =
     if __name__ == .__main__.:
     pragma: no cover

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,5 @@ deps=
 commands=
     coverage run --source=pactman -m py.test --flake8 {posargs}
     coverage html --directory=htmlcov
-    coverage report
-    # TODO: reinstate --fail-under=100
+    # TODO: improve coverage
+    coverage report --fail-under=79


### PR DESCRIPTION
- Fix some issues around mocking request queries and the mock's verification of same
- Fix path matching for query rule application
- Fix header regex matching in mock verification
- Actually use the version passed in to `has_pact_with()`
- Fix some pact v3 generation issues (thanks pan Jacek)