### PR TITLE
 Fix request method resolution in verifier

### DIFF
--- a/pactman/verifier/verify.py
+++ b/pactman/verifier/verify.py
@@ -40,7 +40,7 @@ class Interaction:
             self.result.end()
 
     def run_service(self, service_url):
-        method = self.request['method']
+        method = self.request['method'].upper()
         handler = getattr(self, f'service_{method}', None)
         if handler is None:
             return self.result.fail(f'Request method {method} not implemented in verifier')


### PR DESCRIPTION
If pact files were created with lowercase methods, verifier will fail due to not being able to find the `service_XXX` method, where `XXX` is the request method.