### PR TITLE
Use standard MIT license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,32 +1,6 @@
 MIT License
 
-Copyright (c) 2018 ReeceTech
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-The pactman.mock subpackage is derived in part from the pact-python library from
-the Pact Foundation:
-
-MIT License
-
-Copyright (c) 2017 Pact Foundation
+Copyright (c) 2017 Pact Foundation, 2018 ReeceTech
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This allows GitHub to parse the license correctly and show up in its UI:

https://github.com/cxong/pactman
![image](https://user-images.githubusercontent.com/1083215/50251064-be5cab00-0436-11e9-9231-5eec9b91fe69.png)

https://github.com/cxong/pactman/blob/master/LICENSE
![image](https://user-images.githubusercontent.com/1083215/50251078-ccaac700-0436-11e9-9303-ea4904073681.png)
