### PR TITLE
Fix dict query verification

### DIFF
--- a/pactman/mock/request.py
+++ b/pactman/mock/request.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from .matchers import get_generated_values, get_matching_rules_v2, get_matching_rules_v3
 
 
@@ -23,7 +25,10 @@ class Request:
         self.path = path
         self.body = body
         self.headers = headers
-        self.query = query
+        if isinstance(query, dict):
+            self.query = urlencode(query)
+        else:
+            self.query = query
 
     def json(self, spec_version):
         """Convert the Request to a JSON Pact."""


### PR DESCRIPTION
When `with_request` is called with a dict query, encode it into a string so that it can be parsed in `verify_query`.
****
The documentation implies that the `query` argument for `with_request` accepts both `dict` and `str`, but if you provide a `dict` then the test will fail. Example:

```python
import requests
def test_foobar():
    pact.given("g").upon_receiving("r").with_request("get", "/", query={"foo": "bar"}).will_respond_with(200)
    with pact:
        requests.get(pact.uri, params={"foo": "bar"})
```

The error will say `AttributeError: 'dict' object has no attribute 'decode'`, coming from the `parse_qs(spec_query)` call in `verify.py` `verify_query()`.

One solution would be to parse `spec_query` only if it is a `str`. But this won't work all the time because it is being compared directly against a query parsed by `parse_qs`, [which always parses lists of values](https://stackoverflow.com/q/1024143/2038264) - i.e. `{"foo": "bar"} != {"foo": ["bar"]}`.