### PR TITLE
Handle the port being set in pact mocking setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,10 @@ From there you can use pip to install it:
 
 - Fix `with_request` when called with a dict query (thanks Cong)
 - Make `start_mocking()` and `stop_mocking()` optional with non-server mocking
+- Add shortcut so `python -m pactman.verifier.command_line` is just `python -m pactman`
+  (mostly used in testing before release)
+- Handle the `None` provider state
+- Ensure pact spec versions are consistent across all mocks used to generate a pact file
 
 2.8.0
 

--- a/pactman/__main__.py
+++ b/pactman/__main__.py
@@ -1,0 +1,4 @@
+from .verifier.command_line import main
+
+
+main()

--- a/pactman/mock/consumer.py
+++ b/pactman/mock/consumer.py
@@ -4,7 +4,6 @@ import os
 from .pact import Pact
 from .provider import Provider
 
-
 USE_MOCKING_SERVER = os.environ.get('PACT_USE_MOCKING_SERVER', 'no') == 'yes'
 
 
@@ -36,7 +35,7 @@ class Consumer(object):
         self.name = name
         self.service_cls = service_cls
 
-    def has_pact_with(self, provider, host_name='localhost', port=1234,
+    def has_pact_with(self, provider, host_name='localhost', port=None,
                       log_dir=None, ssl=False, sslcert=None, sslkey=None,
                       pact_dir=None, version='2.0.0', use_mocking_server=USE_MOCKING_SERVER):
         """
@@ -61,7 +60,7 @@ class Consumer(object):
         :type host_name: str
         :param port: The TCP port to use when contacting the Pact mock service.
             This will need to tbe the same port used by your code under test
-            to contact the mock service. It defaults to: 1234
+            to contact the mock service. It defaults to a port >= 8050.
         :type port: int
         :param log_dir: The directory where logs should be written. Defaults to
             the current directory.

--- a/pactman/mock/mock_urlopen.py
+++ b/pactman/mock/mock_urlopen.py
@@ -1,8 +1,8 @@
 import io
 import logging
+
 import urllib3.connectionpool
 import urllib3.poolmanager
-
 from urllib3.response import HTTPResponse
 
 from .pact_request_handler import PactRequestHandler
@@ -18,11 +18,11 @@ class MockPool:
 
     @classmethod
     def add_mock(cls, mock):
-        cls.mocks[mock.config.port] = mock
+        cls.mocks[mock.pact.port] = mock
 
     @classmethod
     def remove_mock(cls, mock):
-        del cls.mocks[mock.config.port]
+        del cls.mocks[mock.pact.port]
 
 
 class MockConnectionPool(urllib3.connectionpool.HTTPConnectionPool, MockPool):

--- a/pactman/mock/request.py
+++ b/pactman/mock/request.py
@@ -1,4 +1,5 @@
-from .matchers import get_generated_values, get_matching_rules_v2, get_matching_rules_v3
+from .matchers import (get_generated_values, get_matching_rules_v2,
+                       get_matching_rules_v3)
 
 
 class Request:

--- a/pactman/mock/response.py
+++ b/pactman/mock/response.py
@@ -1,4 +1,5 @@
-from .matchers import get_generated_values, get_matching_rules_v2, get_matching_rules_v3
+from .matchers import (get_generated_values, get_matching_rules_v2,
+                       get_matching_rules_v3)
 
 
 class Response:

--- a/pactman/test/pact_serialisation/test_body.py
+++ b/pactman/test/pact_serialisation/test_body.py
@@ -1,7 +1,4 @@
-from unittest.mock import Mock
-
-from pactman import Consumer, Provider, EachLike
-from pactman.mock.pact_request_handler import construct_pact
+from pactman import Consumer, EachLike, Provider
 
 
 def test_eachlike():
@@ -13,8 +10,7 @@ def test_eachlike():
         .will_respond_with(200, body={"results": EachLike(1)})
     )
 
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='2.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},

--- a/pactman/test/pact_serialisation/test_full_payload.py
+++ b/pactman/test/pact_serialisation/test_full_payload.py
@@ -1,7 +1,4 @@
-from unittest.mock import Mock
-
 from pactman import Consumer, Provider
-from pactman.mock.pact_request_handler import construct_pact
 
 
 def test_full_payload_v2():
@@ -11,8 +8,7 @@ def test_full_payload_v2():
         .upon_receiving('a request for UserA')
         .with_request('get', '/users/UserA')
         .will_respond_with(200, body={'username': 'UserA'}))
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='2.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},
@@ -35,8 +31,7 @@ def test_full_payload_v3():
      .upon_receiving('a request for UserA')
      .with_request('get', '/users/UserA')
      .will_respond_with(200, body={'username': 'UserA'}))
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='3.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},

--- a/pactman/test/pact_serialisation/test_given.py
+++ b/pactman/test/pact_serialisation/test_given.py
@@ -1,7 +1,28 @@
-from unittest.mock import Mock
+import pytest
 
 from pactman import Consumer, Provider
-from pactman.mock.pact_request_handler import construct_pact
+
+
+@pytest.mark.parametrize('version', ['2.0.0', '3.0.0'])
+def test_null(version):
+    pact = Consumer('consumer').has_pact_with(Provider('provider'), version=version)
+    pact.given(None).upon_receiving("a request").with_request("GET", "/path") \
+        .will_respond_with(200, body='ok')
+
+    result = pact.construct_pact(pact._interactions[0])
+    assert result == {
+        'consumer': {'name': 'consumer'},
+        'provider': {'name': 'provider'},
+        'interactions': [
+            {
+                'description': 'a request',
+                'request': dict(method='GET', path='/path'),
+                'response': dict(status=200, body='ok'),
+
+            }
+        ],
+        'metadata': dict(pactSpecification=dict(version=version))
+    }
 
 
 def test_v2():
@@ -9,8 +30,7 @@ def test_v2():
     pact.given("the condition exists").upon_receiving("a request").with_request("GET", "/path") \
         .will_respond_with(200, body='ok')
 
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='2.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},
@@ -34,8 +54,7 @@ def test_v3():
         dict(name="the user exists", params=dict(username='alex')),
     ]).upon_receiving("a request").with_request("GET", "/path").will_respond_with(200, body='ok')
 
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='3.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},
@@ -64,8 +83,7 @@ def test_v3_and_given():
         .will_respond_with(200, body='ok')
     )
 
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='3.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},

--- a/pactman/test/pact_serialisation/test_request_query.py
+++ b/pactman/test/pact_serialisation/test_request_query.py
@@ -1,7 +1,4 @@
-from unittest.mock import Mock
-
-from pactman import Consumer, Provider, Like
-from pactman.mock.pact_request_handler import construct_pact
+from pactman import Consumer, Like, Provider
 
 
 def test_v2():
@@ -10,8 +7,7 @@ def test_v2():
     pact.given("the condition exists").upon_receiving("a request") \
         .with_request("GET", "/path", query="fields=first,second").will_respond_with(200, body='ok')
 
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='2.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},
@@ -33,8 +29,7 @@ def test_v3():
     pact.given([{'name': "the condition exists", 'params': {}}]).upon_receiving("a request") \
         .with_request("GET", "/path", query=dict(fields='first,second')).will_respond_with(200, body='ok')
 
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='3.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},
@@ -57,8 +52,7 @@ def test_like_v2():
     pact.given("the condition exists").upon_receiving("a request") \
         .with_request("GET", "/path", query=Like("fields=first,second")).will_respond_with(200, body='ok')
 
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='2.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},
@@ -85,8 +79,7 @@ def test_like_v3():
         .will_respond_with(200, body='ok')
     )
 
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='3.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},
@@ -113,8 +106,7 @@ def test_broader_like_v3():
         .will_respond_with(200, body='ok')
     )
 
-    result = construct_pact(Mock(consumer_name='consumer', provider_name='provider',
-                                 version='3.0.0'), pact._interactions[0])
+    result = pact.construct_pact(pact._interactions[0])
     assert result == {
         'consumer': {'name': 'consumer'},
         'provider': {'name': 'provider'},

--- a/pactman/test/test_matching_rules.py
+++ b/pactman/test/test_matching_rules.py
@@ -2,15 +2,14 @@ import collections
 from unittest.mock import Mock
 
 import pytest
-
-from pactman.verifier.matching_rule import (
-    Matcher,
-    RuleFailed,
-    fold_type,
-    split_path,
-    weight_path,
-    MatchType, MatchNull, MatchInclude, MatchEquality, MatchNumber, MatchDecimal, MatchInteger, MatchRegex,
-    InvalidMatcher, log, rule_matchers_v3, rule_matchers_v2)
+from pactman.verifier.matching_rule import (InvalidMatcher, MatchDecimal,
+                                            MatchEquality, Matcher,
+                                            MatchInclude, MatchInteger,
+                                            MatchNull, MatchNumber, MatchRegex,
+                                            MatchType, RuleFailed, fold_type,
+                                            log, rule_matchers_v2,
+                                            rule_matchers_v3, split_path,
+                                            weight_path)
 
 
 def test_stringify():

--- a/pactman/test/test_mock_consumer.py
+++ b/pactman/test/test_mock_consumer.py
@@ -2,8 +2,8 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from pactman.mock.consumer import Consumer
-from pactman.mock.provider import Provider
 from pactman.mock.pact import Pact
+from pactman.mock.provider import Provider
 
 
 class ConsumerTestCase(TestCase):
@@ -23,7 +23,7 @@ class ConsumerTestCase(TestCase):
         self.assertIs(result, self.mock_service.return_value)
         self.mock_service.assert_called_once_with(
             consumer=self.consumer, provider=self.provider,
-            host_name='localhost', port=1234,
+            host_name='localhost', port=None,
             log_dir=None, ssl=False, sslcert=None, sslkey=None,
             pact_dir=None, version='2.0.0', use_mocking_server=False)
 

--- a/pactman/test/test_mock_matchers.py
+++ b/pactman/test/test_mock_matchers.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
-from pactman.mock.matchers import EachLike, Like, Matcher, SomethingLike, \
-    Term, from_term, get_generated_values
+from pactman.mock.matchers import (EachLike, Like, Matcher, SomethingLike,
+                                   Term, from_term, get_generated_values)
 
 
 class MatcherTestCase(TestCase):

--- a/pactman/test/test_mock_pact.py
+++ b/pactman/test/test_mock_pact.py
@@ -1,10 +1,10 @@
 import os
 from unittest import TestCase
-from unittest.mock import patch, call
+from unittest.mock import call, patch
 
 from pactman.mock.consumer import Consumer
-from pactman.mock.provider import Provider
 from pactman.mock.pact import Pact
+from pactman.mock.provider import Provider
 
 
 class PactTestCase(TestCase):
@@ -18,12 +18,12 @@ class PactTestCase(TestCase):
         self.assertEqual(target.host_name, 'localhost')
         self.assertEqual(target.log_dir, os.getcwd())
         self.assertEqual(target.pact_dir, os.getcwd())
-        self.assertEqual(target.port, 1234)
+        self.assertEqual(target.port, Pact.BASE_PORT_NUMBER)
         self.assertIs(target.provider, self.provider)
         self.assertIs(target.ssl, False)
         self.assertIsNone(target.sslcert)
         self.assertIsNone(target.sslkey)
-        self.assertEqual(target.uri, 'http://localhost:1234')
+        self.assertEqual(target.uri, f'http://localhost:{Pact.BASE_PORT_NUMBER}')
         self.assertEqual(target.version, '2.0.0')
         self.assertEqual(len(target._interactions), 0)
 

--- a/pactman/test/test_mock_request.py
+++ b/pactman/test/test_mock_request.py
@@ -1,8 +1,6 @@
-import pytest
-import requests
 from unittest import TestCase
 
-from pactman import Term, Like, Consumer, Provider
+from pactman import Like, Term
 from pactman.mock.request import Request
 
 
@@ -78,23 +76,3 @@ class RequestTestCase(TestCase):
                 }
             }
         })
-
-
-def test_immediate_pact_usage():
-    pact = Consumer('C').has_pact_with(Provider('P')) \
-        .given("g").upon_receiving("r").with_request("get", "/", query={"foo": ["bar"]}).will_respond_with(200)
-    with pact:
-        requests.get(pact.uri, params={"foo": ["bar"]})
-
-    # force a failure
-    pact = Consumer('C').has_pact_with(Provider('P')) \
-        .given("g").upon_receiving("r").with_request("get", "/", query={"bar": ["foo"]}).will_respond_with(200)
-    with pytest.raises(AssertionError):
-        with pact:
-            requests.get(pact.uri, params={"foo": ["bar"]})
-
-    # make sure mocking still works
-    pact = Consumer('C').has_pact_with(Provider('P')) \
-        .given("g").upon_receiving("r").with_request("get", "/", query={"bar": ["foo"]}).will_respond_with(400)
-    with pact:
-        requests.get(pact.uri, params={"bar": ["foo"]})

--- a/pactman/test/test_mock_urlopen.py
+++ b/pactman/test/test_mock_urlopen.py
@@ -1,15 +1,16 @@
 # -*- encoding: utf8 -*-
-import urllib3
-from urllib3.response import HTTPResponse
 from unittest.mock import Mock, call, patch
-import urllib3.poolmanager
 
-from pactman.mock.mock_urlopen import patcher, MockURLOpenHandler
+import urllib3
+import urllib3.poolmanager
+from urllib3.response import HTTPResponse
+
+from pactman.mock.mock_urlopen import MockURLOpenHandler, patcher
 
 
 def test_patched_urlopen_calls_service_with_request_parameters():
-    config = Mock(port=1234)
-    mock_service = Mock(config=config, return_value=HTTPResponse())
+    pact = Mock(port=1234)
+    mock_service = Mock(pact=pact, return_value=HTTPResponse())
     try:
         patcher.add_service(mock_service)
         http = urllib3.PoolManager()

--- a/pactman/test/test_parse_header.py
+++ b/pactman/test/test_parse_header.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pactman.verifier.parse_header import Part, parse_header
 
 

--- a/pactman/test/test_verifier.py
+++ b/pactman/test/test_verifier.py
@@ -3,15 +3,15 @@ import pathlib
 from itertools import chain
 from unittest.mock import Mock
 
-import pytest
 import requests
-import semver
-from restnavigator import Navigator
 
+import pytest
+import semver
 from pactman.verifier.broker_pact import BrokerPact, BrokerPacts, pact_id
 from pactman.verifier.result import Result
-from pactman.verifier.verify import Interaction, RequestVerifier, ResponseVerifier
-
+from pactman.verifier.verify import (Interaction, RequestVerifier,
+                                     ResponseVerifier)
+from restnavigator import Navigator
 
 BASE_DIR = pathlib.Path(__file__).absolute().parents[0]
 

--- a/pactman/verifier/broker_pact.py
+++ b/pactman/verifier/broker_pact.py
@@ -13,7 +13,6 @@ from restnavigator import Navigator
 from .result import LoggedResult
 from .verify import Interaction
 
-
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 

--- a/pactman/verifier/matching_rule.py
+++ b/pactman/verifier/matching_rule.py
@@ -8,7 +8,6 @@ from collections import OrderedDict, defaultdict
 
 from .paths import format_path
 
-
 log = logging.getLogger(__name__)
 
 

--- a/pactman/verifier/result.py
+++ b/pactman/verifier/result.py
@@ -1,6 +1,5 @@
 import logging
 
-
 log = logging.getLogger(__name__)
 
 

--- a/pactman/verifier/verify.py
+++ b/pactman/verifier/verify.py
@@ -3,10 +3,10 @@ from urllib.parse import parse_qs, urljoin
 
 import requests
 
-from .matching_rule import fold_type, nice_type, rule_matchers_v2, rule_matchers_v3, RuleFailed
+from .matching_rule import (RuleFailed, fold_type, nice_type, rule_matchers_v2,
+                            rule_matchers_v3)
 from .parse_header import parse_header
 from .paths import format_path
-
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)


### PR DESCRIPTION
Fixes #3

Also:
- Clean up the pact vs. config malarky internally
- Add shortcut so `python -m pactman.verifier.command_line` is just `python -m pactman`
  (mostly used in testing before release)
- Handle the `None` provider state
- Ensure pact spec versions are consistent across all mocks used to generate a pact file