### PR TITLE
Fix pact file writing issues introduced in 2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ from pactman import Consumer, Provider
 pact = Consumer('Consumer').has_pact_with(Provider('Provider'), version='3.0.0')
 ```
 
+`file_write_mode` defaults to `"overwrite"` and should be that or `"merge"`. Overwrite ensures
+that any existing pact file will be removed when `has_pact_with()` is invoked. Merge will retain
+the pact file and add new pacts to that file. See [writing multiple pacts](#writing-multiple-pacts)
+
 `use_mocking_server` defaults to `False` and controls the mocking method used by `pactman`. The default is to
 patch `urllib3`, which is the library underpinning `requests` and is also used by some other projects. If you
 are using a different library to make your HTTP requests which does not use `urllib3` underneath then you will need
@@ -200,6 +204,20 @@ atexit.register(pact.stop_mocking)
 ``````
 
 You'd then use `pact` to declare pacts between those participants.
+
+### Writing multiple pacts
+
+During a test run you're likely to need to write multiple pact interactions for a consumer/provider
+relationship. `pactman` will manage the pact file using some simple rules:
+
+- When `has_pact_with()` is invoked it will by default remove any existing pact JSON file for the
+  stated consumer & provider.
+- You may invoke `Consumer('Consumer').has_pact_with(Provider('Provider'))` once at the start of
+  your tests. This could be done as a pytest module or session fixture, or through some other
+  mechanism and store it in a variable. By convention this is called `pact` in all of our examples.
+- If that is not suitable, you may manually indicate to `has_pact_with()` that it should either
+  retain (`file_write_mode="merge"`) or remove (`file_write_mode="overwrite"`) the existing
+  pact file.
 
 ### Some words about given()
 You use `given()` to indicate to the provider that they should have some state in order to
@@ -391,6 +409,12 @@ From there you can use pip to install it:
 `pip install ./dist/pactman-N.N.N.tar.gz`
 
 ## Release History
+
+2.10.0
+
+- Allow `has_pact_with()` to accept `file_write_mode`
+- Fix bug introduced in 2.9.0 where generating multiple pacts would result in a single pact
+  being recorded
 
 2.9.0
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ You'd then use `pact` to declare pacts between those participants.
 ### Writing multiple pacts
 
 During a test run you're likely to need to write multiple pact interactions for a consumer/provider
-relationship. `pactman` will manage the pact file using some simple rules:
+relationship. `pactman` will manage the pact file as follows:
 
 - When `has_pact_with()` is invoked it will by default remove any existing pact JSON file for the
   stated consumer & provider.

--- a/pactman/mock/consumer.py
+++ b/pactman/mock/consumer.py
@@ -81,6 +81,7 @@ class Consumer(object):
         :type pact_dir: str
         :param version: The Pact Specification version to use, defaults to
             '2.0.0'.
+        :type version: str
         :param file_write_mode: `overwrite` or `merge`. Use `merge` when
             running multiple mock service instances in parallel for the same
             consumer/provider pair. Ensure the pact file is deleted before

--- a/pactman/mock/consumer.py
+++ b/pactman/mock/consumer.py
@@ -37,7 +37,8 @@ class Consumer(object):
 
     def has_pact_with(self, provider, host_name='localhost', port=None,
                       log_dir=None, ssl=False, sslcert=None, sslkey=None,
-                      pact_dir=None, version='2.0.0', use_mocking_server=USE_MOCKING_SERVER):
+                      pact_dir=None, version='2.0.0', file_write_mode='overwrite',
+                      use_mocking_server=USE_MOCKING_SERVER):
         """
         Create a contract between the `provider` and this consumer.
 
@@ -80,14 +81,21 @@ class Consumer(object):
         :type pact_dir: str
         :param version: The Pact Specification version to use, defaults to
             '2.0.0'.
-        :type version: str
+        :param file_write_mode: `overwrite` or `merge`. Use `merge` when
+            running multiple mock service instances in parallel for the same
+            consumer/provider pair. Ensure the pact file is deleted before
+            running tests when using this option so that interactions deleted
+            from the code are not maintained in the file. Defaults to
+            `overwrite`.
+        :type file_write_mode: str
         :param use_mocking_server: If True the mocking will be done using a
             HTTP server rather than patching urllib3 connections. Can be set
             by the environment variable PACT_USE_MOCKING_SERVER which has
             values "no" (default) or "yes".
         :type use_mocking_server: bool
         :return: A Pact object which you can use to define the specific
-            interactions your code will have with the provider.
+            interactions your c        :type version: str
+ode will have with the provider.
         :rtype: pact.Pact
         """
         if not isinstance(provider, (Provider,)):
@@ -105,5 +113,6 @@ class Consumer(object):
             sslkey=sslkey,
             pact_dir=pact_dir,
             version=version,
+            file_write_mode=file_write_mode,
             use_mocking_server=use_mocking_server,
         )

--- a/pactman/mock/consumer.py
+++ b/pactman/mock/consumer.py
@@ -94,8 +94,7 @@ class Consumer(object):
             values "no" (default) or "yes".
         :type use_mocking_server: bool
         :return: A Pact object which you can use to define the specific
-            interactions your c        :type version: str
-ode will have with the provider.
+            interactions your code will have with the provider.
         :rtype: pact.Pact
         """
         if not isinstance(provider, (Provider,)):

--- a/pactman/mock/pact.py
+++ b/pactman/mock/pact.py
@@ -308,6 +308,7 @@ class Pact(object):
         if not self.use_mocking_server and not self._mock_handler:
             self._auto_mocked = True
             self.start_mocking()
+
         self.setup()
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/pactman/mock/pact_request_handler.py
+++ b/pactman/mock/pact_request_handler.py
@@ -90,14 +90,13 @@ class PactRequestHandler:
         return json.dumps(response['body']).encode(charset)
 
     def write_pact(self, interaction):
-        filename = self.pact.pact_json_filename
         if self.pact.semver["major"] >= 3:
             provider_state_key = 'providerStates'
         else:
             provider_state_key = 'providerState'
 
-        if os.path.exists(filename):
-            with open(filename) as f:
+        if os.path.exists(self.pact.pact_json_filename):
+            with open(self.pact.pact_json_filename) as f:
                 pact = json.load(f)
             existing_version = pact['metadata']['pactSpecification']['version']
             if existing_version != self.pact.version:
@@ -117,5 +116,5 @@ class PactRequestHandler:
         else:
             pact = self.pact.construct_pact(interaction)
 
-        with open(filename, 'w') as f:
+        with open(self.pact.pact_json_filename, 'w') as f:
             json.dump(pact, f, indent=2)

--- a/pactman/mock/pact_request_handler.py
+++ b/pactman/mock/pact_request_handler.py
@@ -96,18 +96,15 @@ class PactRequestHandler:
         else:
             provider_state_key = 'providerState'
 
-        print(filename, os.path.exists(filename))
         if os.path.exists(filename):
             with open(filename) as f:
                 pact = json.load(f)
-            print('hi', pact)
             existing_version = pact['metadata']['pactSpecification']['version']
             if existing_version != self.pact.version:
                 raise PactVersionConflict(f'Existing pact ("{pact["interactions"][0]["description"]}") specifies '
                                           f'version {existing_version} but new pact ("interaction["description"]") '
                                           f'specifies version {self.pact.version}')
             for existing in pact['interactions']:
-                print('hi', existing, interaction)
                 if (existing['description'] == interaction['description']
                         and existing.get(provider_state_key) == interaction.get(provider_state_key)):
                     # already got one of these...
@@ -120,6 +117,5 @@ class PactRequestHandler:
         else:
             pact = self.pact.construct_pact(interaction)
 
-        print('writing', filename, pact)
         with open(filename, 'w') as f:
             json.dump(pact, f, indent=2)


### PR DESCRIPTION
Specifically:

- pass on file_write_mode from has_pact_with()
- document how pact file mege/overwrite works
- fix #27 so interactions are retained
- fix #28 strange key error