### PR TITLE
Make verification fail if missing header specified in interaction

### DIFF
--- a/pactman/test/test_verifier.py
+++ b/pactman/test/test_verifier.py
@@ -414,7 +414,7 @@ class FakeRequest:
             all_testcases(BASE_DIR / 'pact-spec-version-1.1' / 'testcases' / 'request', '1.1.0'),
             all_testcases(BASE_DIR / 'pact-spec-version-2' / 'testcases' / 'request', '2.0.0'),
             all_testcases(BASE_DIR / 'pact-spec-version-3' / 'testcases' / 'request', '3.0.0'),
-            # all_testcases(BASE_DIR / 'testcases-version-2' / 'request', '2.0.0'),
+            all_testcases(BASE_DIR / 'testcases-version-2' / 'request', '2.0.0'),
             all_testcases(BASE_DIR / 'testcases-version-3' / 'request', '3.0.0'),
         ))
     )

--- a/pactman/test/test_verifier.py
+++ b/pactman/test/test_verifier.py
@@ -354,6 +354,22 @@ def test_RequestVerifier_reports_correct_message_when_key_missing(mock_pact, int
     mock_result.fail.assert_called_with("Request element 'key1' is missing", ['body'])
 
 
+def test_ResponseVerifier_checks_for_missing_headers(mock_pact):
+    interaction = {"headers": {"X-Custom-Header": "value1"}}
+    mock_result = Mock()
+    r = ResponseVerifier(mock_pact("2.0.0"), interaction, mock_result)
+    assert r.verify(FakeResponse({"headers": {}})) is False
+    mock_result.fail.assert_called_with("Response missing header 'X-Custom-Header'")
+
+
+def test_RequestVerifier_checks_for_missing_headers(mock_pact):
+    interaction = {"headers": {"X-Custom-Header": "value1"}}
+    mock_result = Mock()
+    r = RequestVerifier(mock_pact("2.0.0"), interaction, mock_result)
+    assert r.verify(FakeRequest({"headers": {}})) is False
+    mock_result.fail.assert_called_with("Request missing header 'X-Custom-Header'")
+
+
 class FakeResponse:
     status = 200
     body = None

--- a/pactman/test/testcases-version-2/request/does-not-match-missing-header.json
+++ b/pactman/test/testcases-version-2/request/does-not-match-missing-header.json
@@ -1,0 +1,12 @@
+{
+  "match": false,
+  "comment": "Does not match if missing header",
+  "expected" : {
+    "headers": {
+      "X-Custom-Header": "value1"
+    }
+  },
+  "actual": {
+    "headers": {}
+  }
+}

--- a/pactman/verifier/verify.py
+++ b/pactman/verifier/verify.py
@@ -182,6 +182,11 @@ class ResponseVerifier:
                     if not self.check_rules(actual, expected, [rule_section, header]):
                         log.info(f'{self.interaction_name} headers: {response.headers}')
                         return False
+                    break
+                else:
+                    self.result.fail(f'{self.interaction_name} missing header {header!r}')
+                    return False
+
         if self.body is not MISSING:
             if not self.check_rules(response.json(), self.body, ['body']):
                 log.info(f'{self.interaction_name} data: {response.json()}')


### PR DESCRIPTION
Fixes #37.

I've included `pactman/test/testcases-version-2/request/does-not-match-missing-header.json` although the files in this folder are being skipped: https://github.com/reecetech/pactman/blob/21e2a6d4fc8e4b9456bcbf62cefa912a739b0c89/pactman/test/test_verifier.py#L401

I tried uncommenting this line but the `params_match_*.json` files then fail. Not sure the state of these.