### PR TITLE
Allow Pact to make requests with cookies

### DIFF
--- a/pactman/mock/pact.py
+++ b/pactman/mock/pact.py
@@ -276,7 +276,7 @@ class Pact(object):
             # clear the interactions once we've attempted to verify, allowing re-use of the mock
             self._interactions[:] = []
 
-    def with_request(self, method, path, body=None, headers=None, query=None):
+    def with_request(self, method, path, body=None, headers=None, query=None, cookies=None):
         """
         Define the request the request that the client is expected to perform.
 
@@ -294,6 +294,9 @@ class Pact(object):
             a dict of keys and values, or a URL encoded string.
             Defaults to None.
         :type query: dict, str, or None
+        :param cookies: The cookies the client is expected to include on with
+            this request. Defaults to None.
+        :type cookies: dict or None
         :rtype: Pact
         """
         # ensure all query values are lists of values
@@ -302,7 +305,7 @@ class Pact(object):
                 if isinstance(v, str):
                     query[k] = [v]
         self._interactions[0]["request"] = Request(
-            method, path, body=body, headers=headers, query=query
+            method, path, body=body, headers=headers, query=query, cookies=cookies
         ).json(self.version)
         return self
 

--- a/pactman/mock/request.py
+++ b/pactman/mock/request.py
@@ -4,7 +4,7 @@ from .matchers import get_generated_values, get_matching_rules_v2, get_matching_
 class Request:
     """Represents an HTTP request and supports Matchers on its properties."""
 
-    def __init__(self, method, path, body=None, headers=None, query=""):
+    def __init__(self, method, path, body=None, headers=None, query="", cookies=None):
         """
         Create a new instance of Request.
 
@@ -18,11 +18,14 @@ class Request:
         :type headers: dict
         :param query: The URI query of the expected request.
         :type query: str or dict
+        :param cookies: The cookies of the expected request.
+        :type cookies: dict
         """
         self.method = method
         self.path = path
         self.body = body
         self.headers = headers
+        self.cookies = cookies
         self.query = query
 
     def json(self, spec_version):
@@ -37,6 +40,9 @@ class Request:
 
         if self.query:
             request["query"] = get_generated_values(self.query)
+
+        if self.cookies:
+            request["cookies"] = get_generated_values(self.cookies)
 
         if spec_version == "2.0.0":
             matchingRules = self.generate_v2_matchingRules()

--- a/pactman/test/test_mock_pact.py
+++ b/pactman/test/test_mock_pact.py
@@ -93,6 +93,7 @@ class PactTestCase(TestCase):
                 body={"key": "value"},
                 headers={"Accept": "application/json"},
                 query="search=test",
+                cookies={'some-cookie': "cookie value"},
             )
             .will_respond_with(200, body="success", headers={"Content-Type": "application/json"})
         )
@@ -111,6 +112,7 @@ class PactTestCase(TestCase):
                 "method": "GET",
                 "body": {"key": "value"},
                 "headers": {"Accept": "application/json"},
+                "cookies": {"some-cookie": "cookie value"},
                 "query": "search=test",
             },
         )
@@ -130,6 +132,7 @@ class PactTestCase(TestCase):
                 body={"key": "value"},
                 headers={"Accept": "application/json"},
                 query={"search": ["test"]},
+                cookies={"some-cookie": "cookie value"},
             )
             .will_respond_with(200, body="success", headers={"Content-Type": "application/json"})
         )
@@ -148,6 +151,7 @@ class PactTestCase(TestCase):
                 "method": "GET",
                 "body": {"key": "value"},
                 "headers": {"Accept": "application/json"},
+                "cookies": {"some-cookie": "cookie value"},
                 "query": {"search": ["test"]},
             },
         )

--- a/pactman/test/test_verifier.py
+++ b/pactman/test/test_verifier.py
@@ -141,7 +141,7 @@ def test_interaction_verify_get(monkeypatch, mock_pact, mock_result_factory, fak
     i.verify("http://provider.example/", "http://provider.example/pact-setup/")
 
     requests.post.assert_not_called()
-    requests.get.assert_called_with("http://provider.example/users-service/user/alex", headers={})
+    requests.get.assert_called_with("http://provider.example/users-service/user/alex", headers={}, cookies={})
     i.response.verify.assert_called()
 
 
@@ -166,7 +166,7 @@ def test_interaction_verify_qs(monkeypatch, mock_pact, mock_result_factory, fake
     i.verify("http://provider.example/", "http://provider.example/pact-setup/")
 
     requests.get.assert_called_with(
-        "http://provider.example/users-service/user/alex", params=dict(a=["b"], c=["d"]), headers={}
+        "http://provider.example/users-service/user/alex", params=dict(a=["b"], c=["d"]), headers={}, cookies={}
     )
     i.response.verify.assert_called()
 
@@ -182,7 +182,7 @@ def test_interaction_verify_post(monkeypatch, mock_pact, mock_result_factory, fa
 
     requests.get.assert_not_called()
     requests.post.assert_called_with(
-        "http://provider.example/users-service/user/alex", json="spam", headers={}
+        "http://provider.example/users-service/user/alex", json="spam", headers={}, cookies={}
     )
     i.response.verify.assert_called()
 
@@ -213,7 +213,7 @@ def test_interaction_verify_delete(monkeypatch, mock_pact, mock_result_factory):
     i.verify("http://provider.example/", "http://provider.example/pact-setup/")
 
     requests.delete.assert_called_with(
-        "http://provider.example/diary-notes/diary-note/1", headers={}
+        "http://provider.example/diary-notes/diary-note/1", headers={}, cookies={}
     )
     i.response.verify.assert_called()
 
@@ -229,7 +229,7 @@ def test_interaction_verify_put(monkeypatch, mock_pact, mock_result_factory, fak
 
     requests.get.assert_not_called()
     requests.put.assert_called_with(
-        "http://provider.example/users-service/user/alex", json="spam", headers={}
+        "http://provider.example/users-service/user/alex", json="spam", headers={}, cookies={}
     )
     i.response.verify.assert_called()
 
@@ -258,7 +258,7 @@ def test_interaction_verify_patch(monkeypatch, mock_pact, mock_result_factory, f
     i.verify("http://provider.example/", "http://provider.example/pact-setup/")
     requests.get.assert_not_called()
     requests.patch.assert_called_with(
-        "http://provider.example/users-service/user/alex", json="spam", headers={}
+        "http://provider.example/users-service/user/alex", json="spam", headers={}, cookies={}
     )
     i.response.verify.assert_called()
 
@@ -421,6 +421,7 @@ def test_provider_state_uses_custom_headers(
     requests.get.assert_called_with(
         "http://provider.example/users-service/user/alex",
         headers={"request_header": "value", "some_header": "some_header"},
+        cookies={}
     )
     i.response.verify.assert_called()
 

--- a/pactman/verifier/verify.py
+++ b/pactman/verifier/verify.py
@@ -71,10 +71,10 @@ class Interaction:
                 # version 2 spec used strings, version 3 uses objects
                 query = parse_qs(query)
             r = requests.get(
-                self._get_url(service_url), params=query, headers=self._request_headers
+                self._get_url(service_url), params=query, headers=self._request_headers, cookies=self._request_cookies
             )
         else:
-            r = requests.get(self._get_url(service_url), headers=self._request_headers)
+            r = requests.get(self._get_url(service_url), headers=self._request_headers, cookies=self._request_cookies)
         return self.response.verify(r)
 
     def service_HEAD(self, service_url):
@@ -84,10 +84,10 @@ class Interaction:
                 # version 2 spec used strings, version 3 uses objects
                 query = parse_qs(query)
             r = requests.head(
-                self._get_url(service_url), params=query, headers=self._request_headers
+                self._get_url(service_url), params=query, headers=self._request_headers, cookies=self._request_cookies
             )
         else:
-            r = requests.head(self._get_url(service_url), headers=self._request_headers)
+            r = requests.head(self._get_url(service_url), headers=self._request_headers, cookies=self._request_cookies)
         return self.response.verify(r)
 
     def service_POST(self, service_url):
@@ -96,12 +96,15 @@ class Interaction:
                 f"POST content type {self._content_type} not implemented in verifier"
             )
         r = requests.post(
-            self._get_url(service_url), json=self._request_payload, headers=self._request_headers
+            self._get_url(service_url),
+            json=self._request_payload,
+            headers=self._request_headers,
+            cookies=self._request_cookies
         )
         return self.response.verify(r)
 
     def service_DELETE(self, service_url):
-        r = requests.delete(self._get_url(service_url), headers=self._request_headers)
+        r = requests.delete(self._get_url(service_url), headers=self._request_headers, cookies=self._request_cookies)
         return self.response.verify(r)
 
     def service_PUT(self, service_url):
@@ -110,7 +113,10 @@ class Interaction:
                 f"PUT content type {self._content_type} not implemented in verifier"
             )
         r = requests.put(
-            self._get_url(service_url), json=self._request_payload, headers=self._request_headers
+            self._get_url(service_url),
+            json=self._request_payload,
+            headers=self._request_headers,
+            cookies=self._request_cookies
         )
         return self.response.verify(r)
 
@@ -120,7 +126,10 @@ class Interaction:
                 f"PATCH content type {self._content_type} not implemented in verifier"
             )
         r = requests.patch(
-            self._get_url(service_url), json=self._request_payload, headers=self._request_headers
+            self._get_url(service_url),
+            json=self._request_payload,
+            headers=self._request_headers,
+            cookies=self._request_cookies
         )
         return self.response.verify(r)
 
@@ -186,6 +195,10 @@ class Interaction:
         headers = dict(self.extra_provider_headers)
         headers.update(self.request.get("headers", {}))
         return headers
+
+    @property
+    def _request_cookies(self):
+        return self.request.get("cookies", {})
 
     @property
     def _request_payload(self):


### PR DESCRIPTION
Adding an option to pass cookies in a similar method to headers. 

This is effectively just a pass-through to requests: https://requests.kennethreitz.org/en/master/user/quickstart/#cookies 

Changes addressing https://github.com/reecetech/pactman/issues/74