### PR TITLE
Add patch request support to mock server

### DIFF
--- a/pactman/mock/mock_server.py
+++ b/pactman/mock/mock_server.py
@@ -135,5 +135,8 @@ class MockHTTPRequestHandler(BaseHTTPRequestHandler, PactRequestHandler):
     def do_PUT(self):
         self.run_request("PUT")
 
+    def do_PATCH(self):
+        self.run_request("PATCH")
+
     def log_message(self, format, *args):
         self.server.log.info("MockServer %s\n" % format % args)


### PR DESCRIPTION
Hi, I try to generate pact for PATCH request, but as I see, it's not supported in [mock server](https://github.com/reecetech/pactman/blob/71ffc3fac5911884358c321ec58f9057da647eca/pactman/mock/mock_server.py#L123). 
So here is my pull request. 