### PR TITLE
:sparkles: Ability to pass custom headers on pytest pact verifier

### DIFF
--- a/pactman/verifier/pytest_plugin.py
+++ b/pactman/verifier/pytest_plugin.py
@@ -95,9 +95,9 @@ class PytestPactVerifier:
         self.interaction = interaction
         self.consumer = consumer
 
-    def verify(self, provider_url, provider_setup):
+    def verify(self, provider_url, provider_setup, extra_provider_headers={}):
         try:
-            self.interaction.verify_with_callable_setup(provider_url, provider_setup)
+            self.interaction.verify_with_callable_setup(provider_url, provider_setup, extra_provider_headers)
         except (Failed, AssertionError) as e:
             raise Failed(str(e)) from None
 

--- a/pactman/verifier/verify.py
+++ b/pactman/verifier/verify.py
@@ -46,7 +46,8 @@ class Interaction:
         finally:
             self.result.end()
 
-    def verify_with_callable_setup(self, service_url, provider_setup):
+    def verify_with_callable_setup(self, service_url, provider_setup, extra_provider_headers={}):
+        self.extra_provider_headers = extra_provider_headers
         self.result.start(self)
         try:
             try:


### PR DESCRIPTION
The verify_with_callable_setup now accepts extra_provider_headers, just like the regular verify used with CLI

Fixes #86 