### PR TITLE
feat: allow json-like response to be handled properly

### DIFF
--- a/pactman/mock/pact_request_handler.py
+++ b/pactman/mock/pact_request_handler.py
@@ -2,6 +2,7 @@ import json
 import os
 import os.path
 import urllib.parse
+import re
 
 from ..verifier.parse_header import get_header_param
 from ..verifier.result import Result
@@ -89,10 +90,12 @@ class PactRequestHandler:
     def handle_response_encoding(self, response, headers):
         # default to content-type to json
         # rfc4627 states JSON is Unicode and defaults to UTF-8
+        json_type = re.compile(r"application/(json|.*\+json|json\-.*)(;|$)")
+
         content_type = [headers[h] for h in headers if h.lower() == "content-type"]
         if content_type:
             content_type = content_type[0]
-            if "application/json" not in content_type:
+            if not json_type.match(content_type):
                 return response["body"]
             charset = get_header_param(content_type, "charset")
             if not charset:

--- a/pactman/test/test_mock_urlopen.py
+++ b/pactman/test/test_mock_urlopen.py
@@ -46,6 +46,22 @@ def test_urlopen_responder_handles_json_body():
     assert r.headers["Content-Type"] == "application/json; charset=UTF-8"
 
 
+def test_urlopen_responder_handles_json_like_body():
+    h = MockURLOpenHandler(Mock())
+
+    interaction = dict(
+        response=dict(
+            body={"message": "hello world"}, 
+            status=200,
+            headers={"Content-Type":"application/geo+json"}
+        )
+    )
+    r = h.respond_for_interaction(interaction)
+
+    assert r.data == b'{"message": "hello world"}'
+    assert r.headers["Content-Type"] == "application/geo+json"
+
+
 def test_urlopen_responder_handles_json_string_body():
     h = MockURLOpenHandler(Mock())
 


### PR DESCRIPTION
Hi there @r1chardj0n3s 👋 

I noticed that right now a header in `will_respond_with` like `'application/geo+json'` would result the response body just being passed through, which causes issues downstream in consumer tests. 
This change handles a geojson or similar response bodies correctly.

wdyt?