### PR TITLE
fix: mock server refusing connections

### DIFF
--- a/pactman/test/test_mock_server.py
+++ b/pactman/test/test_mock_server.py
@@ -1,3 +1,4 @@
+import socket
 from queue import Queue
 from unittest.mock import Mock
 
@@ -21,8 +22,43 @@ def queue(*a):
 )
 def test_correct_result_assertion(mocker, results, exception):
     mocker.patch("pactman.mock.mock_server.Process", autospec=True)
+    mocker.patch("pactman.mock.mock_server.SimpleQueue", autospec=True)
     s = mock_server.Server(Mock())
     s.results = results
     with pytest.raises(exception) as e:
         s.verify()
     assert "spam" in str(e.value)
+
+
+@pytest.fixture
+def unused_port():
+    with socket.socket() as s:
+        s.bind(("localhost", 0))
+        _, port = s.getsockname()[:2]
+        return port
+
+
+@pytest.fixture
+def a_mock_server(tmpdir, unused_port):
+    from pactman import Consumer, Provider
+
+    pact = Consumer("consumer").has_pact_with(
+        Provider("provider"),
+        pact_dir=str(tmpdir),
+        log_dir=str(tmpdir),
+        host_name="localhost",
+        port=unused_port,
+    )
+
+    server = mock_server.Server(pact)
+    yield server
+    server.terminate()
+
+
+def test_mockserver_is_connectable(a_mock_server):
+
+    pact = a_mock_server.pact
+    with socket.socket() as s:
+        # Will fail with ConnectionRefusedError if the server is not already
+        # bound and listening
+        s.connect((pact.host_name, pact.port))


### PR DESCRIPTION
Fixes an issue with the mock server that is use when `PACT_USE_MOCKING_SERVER=yes`.

Said mock server is run in a separate process, and if the process isn't bound to the port yet, connections will be refused.
This adds a notification mechanism so that the mock server is started and listening before any interactions begin.
Specifically, it hooks into the [server_activate()](https://docs.python.org/3.7/library/socketserver.html#socketserver.BaseServer.server_activate) in [HTTPServer](https://docs.python.org/3.7/library/http.server.html#http.server.HTTPServer)'s base class

_I'm aware that this pull request is unlikely to be merged as the repo has no recent activity. But perhaps this fix is useful to a potential future forker._
